### PR TITLE
Cleaning FlowRouter

### DIFF
--- a/src/FlowRouter.tsx
+++ b/src/FlowRouter.tsx
@@ -1,6 +1,5 @@
-import React, {useEffect, useRef, useReducer, Suspense} from 'react';
+import React, {useState, Suspense} from 'react';
 import FlowDispatchTypes from './enums/FlowDispatchTypes';
-import {AuthOption} from './interfaces/AuthOptionInterfaces';
 import FlowDispatchContext from './contexts/FlowDispatchContext';
 import {Flow} from './interfaces/FlowSelectorInterfaces';
 import {IConstants} from './interfaces/IConstants';
@@ -8,130 +7,51 @@ import {defaultComponentMap} from './globals/defaultComponentMap';
 
 import {ComponentStoreMethods, FlowAction, ComponentMap} from './interfaces/FlowRouterInterfaces';
 import useComponentStore from './hooks/useComponentStore';
+import getFlow from './helpers/getFlow';
 
 const FlowController: React.FC<IConstants> = (CONSTANTS: IConstants) => {
-    const options: AuthOption[] = CONSTANTS.verification_options;
-    const useMenu: boolean = options.length > 1;
     const componentMap: ComponentMap = defaultComponentMap;
+    const [step, setStep] = useState('confirmation');
 
-    const flow = useRef<Flow>(createFlow(0));
+    let authIndex: number = 0,
+        theFlow: Flow = getFlow(authIndex, CONSTANTS);
 
-    const [state, dispatch] = useReducer(flowReducer, {
-        step: 'confirmation',
-        authIndex: 0
-    });
-
-    const prevStep: string = flow.current[state.step]![FlowDispatchTypes.BACK] ?? '';
-
-    let TheComponent = renderScreen(state.step);
-    let componentStoreMethods: ComponentStoreMethods = useComponentStore(state.step);
-
-    useEffect(() => {
-        flow.current = createFlow(state.authIndex);
-        // eslint-disable-next-line
-    }, [state.authIndex]);
-
-    function flowReducer(state: any, action: FlowAction): any {
+    function dispatch(action: FlowAction) {
         const {type, payload} = action;
-        const {step} = state;
-        const theFlow: Flow = flow.current;
 
         if (!theFlow.hasOwnProperty(step)) throw new Error(`Referenced step '${step}' does not exist in the flow`);
 
         switch (type) {
-        case FlowDispatchTypes.NEXT:
-            return {
-                ...state,
-                step: theFlow[step]![FlowDispatchTypes.NEXT]
-            };
-        case FlowDispatchTypes.BACK:
-            return {
-                ...state,
-                step: theFlow[step]![FlowDispatchTypes.BACK]
-            };
-        case FlowDispatchTypes.RESTART:
-            return {
-                ...state,
-                step: 'confirmation'
-            };
-        case FlowDispatchTypes.SET_AUTH_METHOD:
-            if ('menu' === state.step) {
-                return {
-                    ...state,
-                    authIndex: payload
-                };
-            } else {
-                throw new Error('Please don\'t try to set the authentication method from outside the Authentication Menu screen');
-            }
-        default:
-            throw new Error('Unknown action type');
+            case FlowDispatchTypes.NEXT:
+                setStep(theFlow[step]![FlowDispatchTypes.NEXT]);
+                break;
+            case FlowDispatchTypes.BACK:
+                if (theFlow.hasOwnProperty(step) && theFlow[step]!.hasOwnProperty(FlowDispatchTypes.BACK)) {
+                    setStep(theFlow[step]![FlowDispatchTypes.BACK]!);
+                }
+                break;
+            case FlowDispatchTypes.RESTART:
+                setStep('confirmation');
+                authIndex = 0;
+                break;
+            case FlowDispatchTypes.SET_AUTH_METHOD:
+                if ('menu' === step) {
+                    authIndex = payload;
+                    theFlow = getFlow(payload, CONSTANTS);
+                    console.log(theFlow);
+                } else {
+                    throw new Error('Please don\'t try to set the authentication method from outside the Authentication Menu screen');
+                }
+                break;
+            default:
+                throw new Error('Unknown action type');
         }
     }
 
-    // TODO - wrap the next four functions in a Hook (useFlow, maybe?)
-    function createFlow(index: number): Flow {
-        const initial: any = createInitialSteps(index);
-        injectAuthMethod(index, initial);
+    const prevStep: string = theFlow[step]![FlowDispatchTypes.BACK] ?? '';
 
-        return initial;
-    }
-
-    function injectAuthMethod(index: number, flow: any) {
-        const beginAt: string = useMenu ? 'menu' : 'confirmation';
-        const sequence: string[] = options[index].sequence;
-
-        if (!sequence.length) throw new Error('You done goofed');
-
-        let currentPoint: string = sequence[0];
-
-        flow[beginAt][FlowDispatchTypes.NEXT] = currentPoint;
-        flow[currentPoint] = {
-            [FlowDispatchTypes.BACK]: beginAt
-        };
-
-        foldSequence(currentPoint, sequence, flow);
-    }
-
-    function foldSequence(currentPoint: string , sequence: string[], flow: any) {
-
-        for (let i = 1; i < sequence.length; i++) {
-            let temp: string = currentPoint;
-            currentPoint = sequence[i];
-
-            flow[temp][FlowDispatchTypes.NEXT] = currentPoint;
-            flow[currentPoint] = {
-                [FlowDispatchTypes.BACK]: temp
-            };
-        }
-
-        flow[currentPoint][FlowDispatchTypes.NEXT] = 'details';
-        flow['details'] = {
-            [FlowDispatchTypes.BACK]: currentPoint
-        };
-    }
-
-    function createInitialSteps(index: number) {
-        const firstScreen = options[index].sequence[0];
-        const ret: any = {
-            confirmation: {
-                [FlowDispatchTypes.NEXT]: 'verificationRequirement'
-            },
-            verificationRequirement: {
-                [FlowDispatchTypes.BACK]: 'confirmation',
-                [FlowDispatchTypes.NEXT]: firstScreen
-            }
-        };
-
-        if (useMenu) {
-            ret.verificationRequirement[FlowDispatchTypes.NEXT] = 'menu';
-            ret['menu'] = {
-                [FlowDispatchTypes.BACK]: 'verificationRequirement',
-                [FlowDispatchTypes.NEXT]: firstScreen
-            }
-        }
-
-        return ret;
-    }
+    let TheComponent = renderScreen(step);
+    let componentStoreMethods: ComponentStoreMethods = useComponentStore(step);
 
     function renderScreen(step: string) {
         Object.assign(componentMap, CONSTANTS.component_map);
@@ -145,8 +65,8 @@ const FlowController: React.FC<IConstants> = (CONSTANTS: IConstants) => {
         <FlowDispatchContext.Provider value={() => dispatch}>
             <Suspense fallback="">
                 <div className="KernelContainer">
-                    <div className="KernelContent" data-cy={state.step}>
-                        <TheComponent {...componentMap[state.step].props} CONSTANTS={CONSTANTS} store={componentStoreMethods} prevScreen={prevStep} authIndex={state.authIndex} />
+                    <div className="KernelContent" data-cy={step}>
+                        <TheComponent {...componentMap[step].props} CONSTANTS={CONSTANTS} store={componentStoreMethods} prevScreen={prevStep} authIndex={authIndex} />
                     </div>
                 </div>
             </Suspense>

--- a/src/globals/defaultComponentMap.ts
+++ b/src/globals/defaultComponentMap.ts
@@ -1,5 +1,5 @@
 import {ComponentMap} from '../interfaces/FlowRouterInterfaces';
-console.log(__dirname);
+
 export const defaultComponentMap: ComponentMap = {
     confirmation: {
         path: '/commonComponents/ConfirmationScreen',

--- a/src/helpers/getFlow.ts
+++ b/src/helpers/getFlow.ts
@@ -1,0 +1,77 @@
+import FlowDispatchTypes from '../enums/FlowDispatchTypes';
+import {IConstants} from '../interfaces/IConstants';
+import {AuthOption} from '../interfaces/AuthOptionInterfaces';
+import {Flow} from '../interfaces/FlowSelectorInterfaces';
+
+export default getFlow;
+
+function getFlow(index: number, CONSTANTS: IConstants): Flow {
+    const options: AuthOption[] = CONSTANTS.verification_options;
+    const useMenu: boolean = options.length > 1;
+
+    return createFlow(index, options, useMenu);
+}
+
+function createFlow(index: number, options: AuthOption[], useMenu: boolean): Flow {
+    const initial: any = createInitialSteps(index, options, useMenu);
+    injectAuthMethod(index, initial, options, useMenu);
+
+    return initial;
+}
+
+function injectAuthMethod(index: number, flow: any, options: AuthOption[], useMenu: boolean) {
+    const beginAt: string = useMenu ? 'menu' : 'confirmation';
+    const sequence: string[] = options[index].sequence;
+
+    if (!sequence.length) throw new Error('You done goofed');
+
+    let currentPoint: string = sequence[0];
+
+    flow[beginAt][FlowDispatchTypes.NEXT] = currentPoint;
+    flow[currentPoint] = {
+        [FlowDispatchTypes.BACK]: beginAt
+    };
+
+    foldSequence(currentPoint, sequence, flow);
+}
+
+function foldSequence(currentPoint: string , sequence: string[], flow: any) {
+
+    for (let i = 1; i < sequence.length; i++) {
+        let temp: string = currentPoint;
+        currentPoint = sequence[i];
+
+        flow[temp][FlowDispatchTypes.NEXT] = currentPoint;
+        flow[currentPoint] = {
+            [FlowDispatchTypes.BACK]: temp
+        };
+    }
+
+    flow[currentPoint][FlowDispatchTypes.NEXT] = 'details';
+    flow['details'] = {
+        [FlowDispatchTypes.BACK]: currentPoint
+    };
+}
+
+function createInitialSteps(index: number, options: AuthOption[], useMenu: boolean) {
+    const firstScreen = options[index].sequence[0];
+    const ret: any = {
+        confirmation: {
+            [FlowDispatchTypes.NEXT]: 'verificationRequirement'
+        },
+        verificationRequirement: {
+            [FlowDispatchTypes.BACK]: 'confirmation',
+            [FlowDispatchTypes.NEXT]: firstScreen
+        }
+    };
+
+    if (useMenu) {
+        ret.verificationRequirement[FlowDispatchTypes.NEXT] = 'menu';
+        ret['menu'] = {
+            [FlowDispatchTypes.BACK]: 'verificationRequirement',
+            [FlowDispatchTypes.NEXT]: firstScreen
+        }
+    }
+
+    return ret;
+}


### PR DESCRIPTION
PR for https://github.com/kiva/ssi-wizard-sdk/issues/6

Had the epiphany that the only part of the `FlowRouter` component that pertains to rendering logic is `step`. Given this, it didn't make a lot of sense to manage anything other than `step` as part of the state of the component. To that end:

* Deprecating `useReducer` - I've implemented that manually
* `authIndex` has been moved out of state control, and is now only useful for picking which `AuthOption` to select when the menu screen is rendered
* `Flow` will be set directly by the dispatch function using the new `getFlow` helper (which precludes us using a Hook for it, because hooks must be called at the top level of a component rather than within a function defined within the component)
* Removed a rogue `console.log`