### PR TITLE
[Issue 84] - Removing "npm run api" command from @kiva/fingerprint-api-simulator

### DIFF
--- a/fingerprint-api-simulator/package.json
+++ b/fingerprint-api-simulator/package.json
@@ -13,8 +13,7 @@
         "test": "NODE_OPTIONS=--experimental-vm-modules jest",
         "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
         "build": "rm -f *.tsbuildinfo & mkdir -p bin/images & tsc & cp -rf src/images bin",
-        "prepare": "npm run build",
-        "api": "swrl"
+        "prepare": "npm run build"
     },
     "bin": {
         "swrl": "bin/simulator.js"


### PR DESCRIPTION
Decided to solve https://github.com/kiva/ssi-wizard-sdk/issues/84 by removing the command. Otherwise you'd have to publish the package and re-install it for testing before you actually finished a PR/got reviews on your code. Seems like a bad way of handling it.

For posterity, you can test your code by running:

```
npm run build
node bin/simulator.js
```